### PR TITLE
Files are now passed along in through2 cb func.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # gulp-folder
 easy to build your framework
 
-* npm install
+Adjusted so files are not discarded in through2 callback.
+
+Might have a nasty side effect of creating not intended folders if uses src with globs, so it might be something to look into later.
 
 ```js
 
@@ -22,6 +24,5 @@ gulp.task('fw', function () {
     }))
         .pipe(gulp.dest('build/framework'));
 });
-
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # gulp-folder
 easy to build your framework
 
-Adjusted so files are not discarded in through2 callback.
-
-Might have a nasty side effect of creating not intended folders if uses src with globs, so it might be something to look into later.
+* npm install
 
 ```js
 
@@ -24,5 +22,6 @@ gulp.task('fw', function () {
     }))
         .pipe(gulp.dest('build/framework'));
 });
+
 
 ```

--- a/folder.js
+++ b/folder.js
@@ -48,10 +48,8 @@ function folder(opt) {
 
     var stream = through2.obj(function (file, enc, cb) {
         //every file will go into this
-        cb();
-    }, function (cb) {
-        //last execute
-        cb();
+        // **Kept transform function so it might be used latter.
+        cb(null, file);
     });
     stream.resume();
     return stream;


### PR DESCRIPTION
Small fix so files are passed along in gulp. There is a side effect that files might create new dirs in destination if it does not have the desired folder.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microlv/gulp-folder/2)

<!-- Reviewable:end -->
